### PR TITLE
fix: missing user session expiration notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,25 @@ Returns an object with the following properties:
 
 stelace.auth.logout()
 
+#### User session expiration
+
+To detect when the user session has expired and handle it properly, you can listen to the following error event:
+```
+stelace.onError('userSessionExpired', function () {
+  // Remove authentication tokens via the token store, e.g.
+  const tokenStore = stelace.getTokenStore()
+  tokenStore.removeTokens()
+  // In browser, you can also notify users that they must reconnect
+  // ...
+})
+```
+
+To stop listening to the event, you can unsubscribe by calling the returned function:
+```
+const unsubscribe = stelace.onError('userSessionExpired', function () { ... })
+unsubscribe() // stops listening
+```
+
 
 
 ### Availability

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -52,7 +52,7 @@ export default class Resource {
     if (!err.response) throw err
 
     const rawResponse = Object.assign({}, err.response)
-    const error = rawResponse.data
+    const error = Object.assign({}, rawResponse.data) // useful for tests (cannot add multiple times `lastResponse`)
 
     const lastResponse = {
       requestId: rawResponse.headers['x-request-id'],

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,3 @@
+export const errorTypes = [
+  'userSessionExpired'
+]

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -158,7 +158,15 @@ function getTokens (self) {
 
             return newTokens
           })
-          .catch(() => tokens)
+          .catch((err) => {
+            if (err.lastResponse && err.lastResponse.statusCode === 403) {
+              const error = Object.assign({}, err, { message: 'User session expired' })
+              self._stelace._emitError('userSessionExpired', error)
+              throw error
+            }
+
+            return tokens
+          })
       }
     })
 }

--- a/lib/stelace.js
+++ b/lib/stelace.js
@@ -1,4 +1,5 @@
 import { createDefaultTokenStore } from './tokenStore'
+import { errorTypes } from './errors'
 
 import ApiKeys from './resources/ApiKeys'
 import Assets from './resources/Assets'
@@ -76,7 +77,8 @@ export class Stelace {
       timeout: Stelace.DEFAULT_TIMEOUT,
       tokenStore: null,
       beforeRefreshToken: null,
-      organizationId: null
+      organizationId: null,
+      errorListeners: {}
     }
 
     this._initResources()
@@ -178,6 +180,27 @@ export class Stelace {
       const key = name[0].toLowerCase() + name.substring(1)
       this[key] = new resources[name](this)
     }
+  }
+
+  onError (type, callback) {
+    if (!errorTypes.includes(type)) throw new Error(`Invalid error type: ${type}`)
+
+    const allListeners = this.getApiField('errorListeners')
+    allListeners[type] = allListeners[type] || []
+    allListeners[type].push(callback)
+
+    return function unsubscribe () {
+      allListeners[type] = allListeners[type].filter(cb => cb !== callback)
+    }
+  }
+
+  _emitError (type, error) {
+    const allListeners = this.getApiField('errorListeners')
+
+    const typeListeners = allListeners[type] || []
+    typeListeners.forEach(listener => {
+      listener(error)
+    })
   }
 }
 


### PR DESCRIPTION
There was no way to know when a user session has expired.
Add an error event that one can subscribe to handle the expiration properly.