### PR TITLE
feat: add saved search actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,10 @@ stelace.savedSearch.read(savedSearchId, [queryParams], [options], [callback])
 
 stelace.savedSearch.create(data, [options], [callback])
 
+`data` is the object that is passed to `POST /search` endpoint (same endpoint as `stelace.search.results` method), but with two differences:
+- `stelace.savedSearch.create` method automatically sets `save` to `true`
+- the property `name` is required to create a saved search
+
 #### Update a saved search
 
 stelace.savedSearch.update(savedSearchId, data, [options], [callback])

--- a/README.md
+++ b/README.md
@@ -680,10 +680,37 @@ stelace.roles.remove(roleId, [options], [callback])
 
 
 
+### Saved searches
+
+#### List saved searches
+
+stelace.savedSearch.list([queryParams], [options], [callback])
+
+#### Read a saved search
+
+stelace.savedSearch.read(savedSearchId, [queryParams], [options], [callback])
+
+#### Create a saved search
+
+stelace.savedSearch.create(data, [options], [callback])
+
+#### Update a saved search
+
+stelace.savedSearch.update(savedSearchId, data, [options], [callback])
+
+#### Remove a saved search
+
+stelace.savedSearch.remove(savedSearchId, [options], [callback])
+
+
+
 ### Search
 
 #### Search assets
 
+stelace.search.results(data, [options], [callback])
+
+Deprecated version:
 stelace.search.list(data, [options], [callback])
 
 

--- a/lib/resources/SavedSearch.js
+++ b/lib/resources/SavedSearch.js
@@ -1,0 +1,20 @@
+import Resource from '../Resource'
+
+const method = Resource.method
+
+export default class SavedSearch extends Resource {}
+
+Resource.addBasicMethods(SavedSearch, {
+  path: '/search',
+  includeBasic: ['list', 'read', 'update', 'remove']
+})
+
+SavedSearch.prototype.create = method({
+  path: '/search',
+  method: 'POST',
+  beforeRequest: (requestParams) => {
+    requestParams.data = requestParams.data || {}
+    requestParams.data.save = true
+    return requestParams
+  }
+})

--- a/lib/resources/Search.js
+++ b/lib/resources/Search.js
@@ -5,9 +5,15 @@ const method = Resource.method
 
 export default class Search extends Resource {}
 
-Search.prototype.list = method({
+Search.prototype.results = method({
   path: '/search',
   method: 'POST',
+  beforeRequest: (requestParams) => {
+    if (requestParams.data && requestParams.data.save) {
+      requestParams.data.save = false
+    }
+    return requestParams
+  },
   transformResponseData: (res) => {
     const lastResponse = res.lastResponse
 
@@ -27,3 +33,5 @@ Search.prototype.list = method({
     return newResponse
   }
 })
+
+Search.prototype.list = Search.prototype.results

--- a/lib/stelace.js
+++ b/lib/stelace.js
@@ -17,6 +17,7 @@ import Permissions from './resources/Permissions'
 import Providers from './resources/Providers'
 import Ratings from './resources/Ratings'
 import Roles from './resources/Roles'
+import SavedSearch from './resources/SavedSearch'
 import Search from './resources/Search'
 import Transactions from './resources/Transactions'
 import Users from './resources/Users'
@@ -40,6 +41,7 @@ const resources = {
   Providers,
   Ratings,
   Roles,
+  SavedSearch,
   Search,
   Transactions,
   Users,

--- a/test/resources/SavedSearch.spec.js
+++ b/test/resources/SavedSearch.spec.js
@@ -1,0 +1,75 @@
+import test from 'blue-tape'
+
+import { getSpyableStelace } from '../../testUtils'
+
+const stelace = getSpyableStelace()
+
+test('list: sends the correct request', (t) => {
+  return stelace.savedSearch.list()
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'GET',
+        path: '/search',
+        data: {},
+        queryParams: {},
+        headers: {}
+      })
+    })
+})
+
+test('read: sends the correct request', (t) => {
+  return stelace.savedSearch.read('savedSearch_1')
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'GET',
+        path: '/search/savedSearch_1',
+        data: {},
+        queryParams: {},
+        headers: {}
+      })
+    })
+})
+
+test('create: sends the correct request with save option automatically set to true', (t) => {
+  const data = {
+    name: 'My search query',
+    query: 'some value'
+  }
+
+  return stelace.savedSearch.create(data)
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'POST',
+        path: '/search',
+        data: Object.assign({}, data, { save: true }), // automatically set `save` to true
+        queryParams: {},
+        headers: {}
+      })
+    })
+})
+
+test('update: sends the correct request', (t) => {
+  return stelace.savedSearch.update('savedSearch_1', { name: 'Custom query' })
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'PATCH',
+        path: '/search/savedSearch_1',
+        data: { name: 'Custom query' },
+        queryParams: {},
+        headers: {}
+      })
+    })
+})
+
+test('remove: sends the correct request', (t) => {
+  return stelace.savedSearch.remove('savedSearch_1')
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'DELETE',
+        path: '/search/savedSearch_1',
+        data: {},
+        queryParams: {},
+        headers: {}
+      })
+    })
+})

--- a/test/resources/Search.spec.js
+++ b/test/resources/Search.spec.js
@@ -4,7 +4,54 @@ import { getSpyableStelace } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
-test('list: sends the correct request', (t) => {
+test('results: sends the correct request', (t) => {
+  const data = {
+    query: 'Toyota',
+    page: 2,
+    nbResultsPerPage: 10,
+    location: {
+      latitude: 22,
+      longitude: 10
+    }
+  }
+
+  return stelace.search.results(data)
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'POST',
+        path: '/search',
+        data,
+        queryParams: {},
+        headers: {}
+      })
+    })
+})
+
+test('results: automatically set save to false if it is true', (t) => {
+  const data = {
+    query: 'Toyota',
+    page: 2,
+    nbResultsPerPage: 10,
+    location: {
+      latitude: 22,
+      longitude: 10
+    },
+    save: true
+  }
+
+  return stelace.search.results(data)
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'POST',
+        path: '/search',
+        data: Object.assign({}, data, { save: false }), // automatically set `save` to false
+        queryParams: {},
+        headers: {}
+      })
+    })
+})
+
+test('[DEPRECATED] list (alias of results): sends the correct request', (t) => {
   const data = {
     query: 'Toyota',
     page: 2,


### PR DESCRIPTION
And deprecate search.list in favor of search.results
to prevent confusion between search.list and savedSearch.list