### PR TITLE
feat: implement auto-pagination for list/paginated endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,31 @@ stelace.categories.create({
 })
 ```
 
+### Auto-pagination
+
+We provide two ways to retrieve and perform actions on endpoints that have a large number of results. These methods can be used with list endpoints or paginated endpoints.
+
+#### Async iterators (`for-await-of`)
+
+If you are in an environment that supports [async iteration](https://github.com/tc39/proposal-async-iteration#the-async-iteration-statement-for-await-of), such as Node 10+ or [Babel](https://babeljs.io/docs/en/babel-plugin-transform-async-generator-functions), you can auto-paginate with the following code:
+
+```js
+for await (const asset of stelace.assets.list({ nbResultsPerPage: 100 })) {
+  doSomething(asset)
+  if (shouldStop()) break
+}
+```
+
+#### `autoPagingToArray`
+
+If the number of results is relative small, you can use the `autoPagingToArray` method to auto-paginate. The parameter `limit` is required and cannot exceed 10,000 to prevent consuming too much memory.
+
+```js
+const users = await stelace.users
+  .list({ createdDate: { gte: lastYear }, nbResultsPerPage: 100 })
+  .autoPagingToArray({ limit: 10000 })
+```
+
 ### Configuring Timeout
 
 Request timeout in case of network failure is configurable (the default is 30 seconds):

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ We provide two ways to retrieve and perform actions on endpoints that have a lar
 If you are in an environment that supports [async iteration](https://github.com/tc39/proposal-async-iteration#the-async-iteration-statement-for-await-of), such as Node 10+ or [Babel](https://babeljs.io/docs/en/babel-plugin-transform-async-generator-functions), you can auto-paginate with the following code:
 
 ```js
-for await (const asset of stelace.assets.list({ nbResultsPerPage: 100 })) {
+for await (const asset of stelace.assets.list()) {
   doSomething(asset)
   if (shouldStop()) break
 }
@@ -332,7 +332,7 @@ If the number of results is relative small, you can use the `autoPagingToArray` 
 
 ```js
 const users = await stelace.users
-  .list({ createdDate: { gte: lastYear }, nbResultsPerPage: 100 })
+  .list({ createdDate: { gte: lastYear }})
   .autoPagingToArray({ limit: 10000 })
 ```
 

--- a/lib/autoPagination.js
+++ b/lib/autoPagination.js
@@ -1,0 +1,147 @@
+import { asCallback } from './utils'
+import makeRequest from './makeRequest'
+
+export default function makeAutoPaginationMethods (self, requestArgs, spec, firstPagePromise) {
+  const promiseCache = { currentPromise: null }
+  let listPromise = firstPagePromise
+  let i = 0
+
+  function iterate (response) {
+    const { paginationMeta } = response
+
+    const isPaginated = Boolean(paginationMeta)
+
+    if (i < response.length) {
+      const value = response[i]
+      i += 1
+      return { value, done: false }
+    } else if (isPaginated) {
+      const isOffsetPaginated = typeof paginationMeta.nbPages !== 'undefined'
+      const isCursorPaginated = typeof paginationMeta.hasNextPage !== 'undefined'
+
+      const { page, nbPages, hasNextPage } = paginationMeta
+
+      let fetchNextPage
+      let newPageParams
+
+      if (isOffsetPaginated) {
+        fetchNextPage = page < nbPages
+        newPageParams = { page: page + 1 }
+      } else if (isCursorPaginated) {
+        fetchNextPage = hasNextPage
+        newPageParams = { startingAfter: paginationMeta.endCursor }
+      }
+
+      if (fetchNextPage) {
+        // reset counter, request next page, and recurse
+        i = 0
+        listPromise = makeRequest(self, requestArgs, spec, newPageParams)
+        return listPromise.then(iterate)
+      }
+    }
+
+    return { value: undefined, done: true }
+  }
+
+  function asyncIteratorNext () {
+    return memoizedPromise(promiseCache, (resolve, reject) => {
+      return listPromise
+        .then(iterate)
+        .then(resolve)
+        .catch(reject)
+    })
+  }
+
+  const autoPagingToArray = makeAutoPagingToArray(asyncIteratorNext)
+
+  const autoPaginationMethods = {
+    autoPagingToArray,
+
+    // Async iterator functions
+    next: asyncIteratorNext,
+    return: () => {
+      // This is required for `break`
+      return {}
+    },
+    [getAsyncIteratorSymbol()]: () => {
+      return autoPaginationMethods
+    },
+  }
+  return autoPaginationMethods
+}
+
+// /////// //
+// HELPERS //
+// /////// //
+
+function getAsyncIteratorSymbol () {
+  if (typeof Symbol !== 'undefined' && Symbol.asyncIterator) {
+    return Symbol.asyncIterator
+  }
+  // Follow the convention from libraries like iterall: https://github.com/leebyron/iterall#asynciterator-1
+  return '@@asyncIterator'
+}
+
+/**
+ * If a user calls `.next()` multiple times in parallel,
+ * return the same result until something has resolved
+ * to prevent page-turning race conditions.
+ */
+function memoizedPromise (promiseCache, cb) {
+  if (promiseCache.currentPromise) {
+    return promiseCache.currentPromise
+  }
+  promiseCache.currentPromise = new Promise(cb).then((ret) => {
+    promiseCache.currentPromise = undefined
+    return ret
+  })
+  return promiseCache.currentPromise
+}
+
+function makeAutoPagingToArray (asyncIteratorNext) {
+  return function autoPagingToArray (opts, onDone) {
+    const limit = opts && opts.limit
+    if (!limit) {
+      throw new Error(
+        'You must pass a `limit` option to autoPagingToArray, e.g., `autoPagingToArray({ limit: 1000 });`.'
+      )
+    }
+    if (limit > 10000) {
+      throw new Error(
+        'You cannot specify a limit of more than 10,000 objects to fetch in `autoPagingToArray`.'
+      )
+    }
+    const promise = new Promise((resolve, reject) => {
+      const objects = []
+      wrapAsyncIteratorWithCallback(asyncIteratorNext, (obj) => {
+        return new Promise((resolve) => {
+          objects.push(obj)
+          const keepFetching = objects.length < limit
+          resolve(keepFetching)
+        })
+      })
+        .then(() => resolve(objects))
+        .catch(reject)
+    })
+    return asCallback(promise, onDone)
+  }
+}
+
+function wrapAsyncIteratorWithCallback (asyncIteratorNext, onObject) {
+  return new Promise((resolve, reject) => {
+    function handleIteration (iterResult) {
+      if (iterResult.done) return resolve()
+
+      const obj = iterResult.value
+      return onObject(obj)
+        .then((shouldContinue) => {
+          if (shouldContinue === false) return handleIteration({ done: true })
+          else return asyncIteratorNext().then(handleIteration)
+        })
+    }
+
+    asyncIteratorNext()
+      .then(handleIteration)
+      .catch(reject)
+  })
+}

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -8,7 +8,7 @@ import {
   isPromise
 } from './utils'
 
-function getRequestOpts (requestArgs, spec, tokens) {
+function getRequestOpts (requestArgs, spec, tokens, overrideData = {}) {
   const {
     path,
     method = 'GET',
@@ -46,8 +46,10 @@ function getRequestOpts (requestArgs, spec, tokens) {
 
   if (method === 'GET') {
     queryParams = getDataFromArgs(args)
+    queryParams = Object.assign({}, queryParams, overrideData)
   } else {
     data = getDataFromArgs(args)
+    data = Object.assign({}, data, overrideData)
   }
 
   const options = getOptionsFromArgs(args)
@@ -202,11 +204,11 @@ function getNewAccessToken (self, refreshToken) {
     .then(res => res.accessToken)
 }
 
-export default function makeRequest (self, requestArgs, spec) {
+export default function makeRequest (self, requestArgs, spec, overrideData) {
   return Promise.resolve()
     .then(() => getTokens(self))
     .then(tokens => {
-      const opts = getRequestOpts(requestArgs, spec, tokens)
+      const opts = getRequestOpts(requestArgs, spec, tokens, overrideData)
 
       let requestParams = {
         path: opts.requestPath,

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -5,8 +5,19 @@ import {
   getOptionsFromArgs,
   addReadOnlyProperty,
   decodeJwtToken,
-  isPromise
+  isPromise,
+  maxNbResultsPerPage,
 } from './utils'
+
+// For version: 2019-05-20
+const nonPaginatedEndpoints = [
+  '/asset-types',
+  '/categories',
+  '/roles',
+  '/workflows',
+  '/webhooks',
+]
+const nonPaginatedEndpointsVersion = '2019-05-20'
 
 function getRequestOpts (requestArgs, spec, tokens, overrideData = {}) {
   const {
@@ -209,6 +220,13 @@ export default function makeRequest (self, requestArgs, spec, overrideData) {
     .then(() => getTokens(self))
     .then(tokens => {
       const opts = getRequestOpts(requestArgs, spec, tokens, overrideData)
+      const apiVersion = opts.headers['x-stelace-version'] || self._stelace.getApiField('version')
+
+      if (spec.isList && typeof opts.queryParams.nbResultsPerPage === 'undefined') {
+        const noPagination = nonPaginatedEndpoints.includes(opts.requestPath) &&
+          apiVersion === nonPaginatedEndpointsVersion
+        if (!noPagination) opts.queryParams.nbResultsPerPage = maxNbResultsPerPage
+      }
 
       let requestParams = {
         path: opts.requestPath,

--- a/lib/method.js
+++ b/lib/method.js
@@ -1,5 +1,6 @@
 import { asCallback } from './utils'
 import makeRequest from './makeRequest'
+import makeAutoPaginationMethods from './autoPagination'
 
 /**
  * Create an API method from the spec
@@ -17,6 +18,16 @@ export default function method (spec) {
     const callback = typeof args[args.length - 1] === 'function' && args.pop()
 
     const requestPromise = asCallback(makeRequest(this, args, spec), callback)
+
+    if (spec.isList) {
+      const autoPaginationMethods = makeAutoPaginationMethods(
+        this,
+        args,
+        spec,
+        requestPromise
+      )
+      Object.assign(requestPromise, autoPaginationMethods)
+    }
 
     return requestPromise
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,8 @@ const OPTIONS_KEYS = [
   'stelaceOrganizationId'
 ]
 
+export const maxNbResultsPerPage = 100
+
 const hasOwn = {}.hasOwnProperty
 
 export const isApiKey = (key) => {

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -2,7 +2,7 @@ import test from 'blue-tape'
 
 import { clone } from '../lib/utils'
 
-import { getSpyableStelace, getStelaceStub } from '../testUtils'
+import { getSpyableStelace, getStelaceStub, maxNbResultsPerPage } from '../testUtils'
 
 import Resource from '../lib/Resource'
 
@@ -55,7 +55,7 @@ test('Extracts pagination "results" from response', (t) => {
   }
 
   const baseURL = api.customAttributes.getBaseURL()
-  api.stubRequest(`${baseURL}/custom-attributes`, res)
+  api.stubRequest(`${baseURL}/custom-attributes?nbResultsPerPage=${maxNbResultsPerPage}`, res)
 
   return api.customAttributes.list()
     .then(ca => {
@@ -114,7 +114,7 @@ test('Passes plain array response as is', (t) => {
   }
 
   const baseURL = api.categories.getBaseURL()
-  api.stubRequest(`${baseURL}/categories`, res)
+  api.stubRequest(`${baseURL}/categories?nbResultsPerPage=${maxNbResultsPerPage}`, res)
 
   return api.categories.list()
     .then(cat => {

--- a/test/autoPagination.spec.js
+++ b/test/autoPagination.spec.js
@@ -1,0 +1,317 @@
+import test from 'blue-tape'
+import _ from 'lodash'
+
+import { getStelaceStub } from '../testUtils'
+import qs from 'querystring'
+
+const nbResults = 1000 // total number of results
+const nbResultsPerPage = 1 // requests objects one by one
+const maxAutopaginationLimit = 10000
+
+const getUrl = (urlPath, params) => `${urlPath}?${qs.stringify(params)}`
+const getRequestId = num => `requestId${num}`
+
+const initNonPaginationStubs = ({ stelace, endpointUrl, getObject, nbResults }) => {
+  stelace.stubRequest(endpointUrl, {
+    status: 200,
+    headers: {
+      'x-request-id': getRequestId(1)
+    },
+    response: _.range(1, nbResults + 1).map(getObject) // returns all objects at once
+  })
+}
+
+const initOffsetPaginationStubs = ({ stelace, endpointUrl, params, getObject, nbResults }) => {
+  _.range(1, nbResults + 1).forEach((page) => {
+    const urlParams = Object.assign({}, params)
+    if (page !== 1) urlParams.page = page
+
+    const url = getUrl(endpointUrl, urlParams)
+
+    stelace.stubRequest(url, {
+      status: 200,
+      headers: {
+        'x-request-id': getRequestId(page)
+      },
+      response: {
+        nbResults,
+        nbPages: nbResults,
+        page,
+        nbResultsPerPage,
+        results: [getObject(page)], // returns objects one by one
+      }
+    })
+  })
+}
+
+const initCursorPaginationStubs = ({ stelace, endpointUrl, params, getObject, nbResults }) => {
+  const getCursor = (page) => `cursor${page}`
+
+  _.range(1, nbResults + 1).forEach((page) => {
+    const urlParams = Object.assign({}, params)
+
+    const cursor = getCursor(page)
+    const previousCursor = getCursor(page - 1)
+    if (page !== 1) urlParams.startingAfter = previousCursor
+
+    const url = getUrl(endpointUrl, urlParams)
+
+    stelace.stubRequest(url, {
+      status: 200,
+      headers: {
+        'x-request-id': getRequestId(page)
+      },
+      response: {
+        startCursor: cursor,
+        endCursor: cursor,
+        hasPreviousPage: page !== 1,
+        hasNextPage: page !== nbResults,
+        nbResultsPerPage,
+        results: [getObject(page)], // returns objects one by one
+      }
+    })
+  })
+}
+
+test('async iterator: handles non-paginated endpoints', async (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.roles.getBaseURL()
+  const endpointUrl = `${baseURL}/roles`
+
+  const getRole = (num) => ({ id: `role_${num}`, name: `Role ${num}` })
+  initNonPaginationStubs({ stelace, endpointUrl, getObject: getRole, nbResults })
+
+  const expectedResults = _.range(1, nbResults + 1).map(getRole)
+
+  stelace.startStub()
+  initNonPaginationStubs({ stelace, endpointUrl, getObject: getRole, nbResults })
+
+  const roles = []
+  for await (const role of stelace.roles.list()) {
+    roles.push(role)
+    // no break to iterate over all results
+  }
+
+  t.deepEqual(roles, expectedResults)
+
+  stelace.stopStub()
+})
+
+test('autoPagingToArray: handles non-paginated endpoints', (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.roles.getBaseURL()
+  const endpointUrl = `${baseURL}/roles`
+
+  const getRole = (num) => ({ id: `role_${num}`, name: `Role ${num}` })
+  initNonPaginationStubs({ stelace, endpointUrl, getObject: getRole, nbResults })
+
+  const expectedResults = _.range(1, nbResults + 1).map(getRole)
+
+  return stelace.roles.list().autoPagingToArray({ limit: maxAutopaginationLimit })
+    .then(roles => {
+      t.deepEqual(roles, expectedResults)
+    })
+    .then(() => stelace.stopStub())
+    .catch(err => {
+      stelace.stopStub()
+      throw err
+    })
+})
+
+test('async iterator: autopaginate offset pagination endpoint', async (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.assets.getBaseURL()
+  const endpointUrl = `${baseURL}/assets`
+
+  const getAsset = (num) => ({ id: `asset_${num}`, name: `Asset ${num}` })
+  const params = {
+    nbResults,
+    nbResultsPerPage,
+    orderBy: 'createdDate',
+    order: 'asc',
+  }
+
+  initOffsetPaginationStubs({ stelace, endpointUrl, params, getObject: getAsset, nbResults })
+
+  const expectedResults = _.range(1, nbResults + 1).map(getAsset)
+
+  const assets = []
+  for await (const asset of stelace.assets.list(params)) {
+    assets.push(asset)
+    // no break to iterate over all results
+  }
+
+  t.deepEqual(assets, expectedResults)
+
+  stelace.stopStub()
+})
+
+test('autoPagingToArray: autopaginate offset pagination endpoint', (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.assets.getBaseURL()
+  const endpointUrl = `${baseURL}/assets`
+
+  const getAsset = (num) => ({ id: `asset_${num}`, name: `Asset ${num}` })
+  const params = {
+    nbResults,
+    nbResultsPerPage,
+    orderBy: 'createdDate',
+    order: 'asc',
+  }
+
+  initOffsetPaginationStubs({ stelace, endpointUrl, params, getObject: getAsset, nbResults })
+
+  const expectedResults = _.range(1, nbResults + 1).map(getAsset)
+
+  return stelace.assets.list(params).autoPagingToArray({ limit: maxAutopaginationLimit })
+    .then(assets => {
+      t.deepEqual(assets, expectedResults)
+    })
+    .then(() => stelace.stopStub())
+    .catch(err => {
+      stelace.stopStub()
+      throw err
+    })
+})
+
+test('async iterator: autopaginate cursor pagination endpoint', async (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.assets.getBaseURL()
+  const endpointUrl = `${baseURL}/assets`
+
+  const getAsset = (num) => ({ id: `asset_${num}`, name: `Asset ${num}` })
+  const params = {
+    nbResults,
+    nbResultsPerPage,
+    orderBy: 'createdDate',
+    order: 'asc',
+  }
+
+  initCursorPaginationStubs({ stelace, endpointUrl, params, getObject: getAsset, nbResults })
+
+  const expectedResults = _.range(1, nbResults + 1).map(getAsset)
+
+  const assets = []
+  for await (const asset of stelace.assets.list(params)) {
+    assets.push(asset)
+    // no break to iterate over all results
+  }
+
+  t.deepEqual(assets, expectedResults)
+
+  stelace.stopStub()
+})
+
+test('autoPagingToArray: autopaginate cursor pagination endpoint', (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.assets.getBaseURL()
+  const endpointUrl = `${baseURL}/assets`
+
+  const getAsset = (num) => ({ id: `asset_${num}`, name: `Asset ${num}` })
+  const params = {
+    nbResults,
+    nbResultsPerPage,
+    orderBy: 'createdDate',
+    order: 'asc',
+  }
+
+  initCursorPaginationStubs({ stelace, endpointUrl, params, getObject: getAsset, nbResults })
+
+  const expectedResults = _.range(1, nbResults + 1).map(getAsset)
+
+  return stelace.assets.list(params).autoPagingToArray({ limit: maxAutopaginationLimit })
+    .then(assets => {
+      t.deepEqual(assets, expectedResults)
+    })
+    .then(() => stelace.stopStub())
+    .catch(err => {
+      stelace.stopStub()
+      throw err
+    })
+})
+
+test('async iterator: stops when there is a break', async (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.assets.getBaseURL()
+  const endpointUrl = `${baseURL}/assets`
+
+  const getAsset = (num) => ({ id: `asset_${num}`, name: `Asset ${num}` })
+  const params = {
+    nbResults,
+    nbResultsPerPage,
+    orderBy: 'createdDate',
+    order: 'asc',
+  }
+
+  initCursorPaginationStubs({ stelace, endpointUrl, params, getObject: getAsset, nbResults })
+
+  const limit = 10
+  let i = limit
+
+  const expectedResults = _.range(1, limit + 1).map(getAsset)
+
+  const assets = []
+  for await (const asset of stelace.assets.list(params)) {
+    assets.push(asset)
+
+    i -= 1
+    if (i === 0) break
+  }
+
+  t.deepEqual(assets, expectedResults)
+
+  stelace.stopStub()
+})
+
+test('autoPagingToArray: stops when the limit is reached', (t) => {
+  const stelace = getStelaceStub()
+
+  stelace.startStub()
+
+  const baseURL = stelace.assets.getBaseURL()
+  const endpointUrl = `${baseURL}/assets`
+
+  const getAsset = (num) => ({ id: `asset_${num}`, name: `Asset ${num}` })
+  const params = {
+    nbResults,
+    nbResultsPerPage,
+    orderBy: 'createdDate',
+    order: 'asc',
+  }
+
+  initCursorPaginationStubs({ stelace, endpointUrl, params, getObject: getAsset, nbResults })
+
+  const limit = 10
+  const expectedResults = _.range(1, limit + 1).map(getAsset)
+
+  return stelace.assets.list(params).autoPagingToArray({ limit })
+    .then(assets => {
+      t.deepEqual(assets, expectedResults)
+    })
+    .then(() => stelace.stopStub())
+    .catch(err => {
+      stelace.stopStub()
+      throw err
+    })
+})

--- a/test/autoPagination.spec.js
+++ b/test/autoPagination.spec.js
@@ -1,7 +1,7 @@
 import test from 'blue-tape'
 import _ from 'lodash'
 
-import { getStelaceStub } from '../testUtils'
+import { getStelaceStub, maxNbResultsPerPage } from '../testUtils'
 import qs from 'querystring'
 
 const nbResults = 1000 // total number of results
@@ -12,7 +12,9 @@ const getUrl = (urlPath, params) => `${urlPath}?${qs.stringify(params)}`
 const getRequestId = num => `requestId${num}`
 
 const initNonPaginationStubs = ({ stelace, endpointUrl, getObject, nbResults }) => {
-  stelace.stubRequest(endpointUrl, {
+  const url = getUrl(endpointUrl, { nbResultsPerPage: maxNbResultsPerPage })
+
+  stelace.stubRequest(url, {
     status: 200,
     headers: {
       'x-request-id': getRequestId(1)

--- a/test/resources/AssetTypes.spec.js
+++ b/test/resources/AssetTypes.spec.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 
-import { getSpyableStelace } from '../../testUtils'
+import { getSpyableStelace, maxNbResultsPerPage } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
@@ -11,8 +11,25 @@ test('list: sends the correct request', (t) => {
         method: 'GET',
         path: '/asset-types',
         data: {},
-        queryParams: {},
+        queryParams: {
+          nbResultsPerPage: maxNbResultsPerPage // automatically added
+        },
         headers: {}
+      })
+    })
+})
+
+test('[2019-05-20] list: sends the correct request', (t) => {
+  return stelace.assetTypes.list({ stelaceVersion: '2019-05-20' })
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'GET',
+        path: '/asset-types',
+        data: {},
+        queryParams: {},
+        headers: {
+          'x-stelace-version': '2019-05-20'
+        }
       })
     })
 })

--- a/test/resources/Availabilities.spec.js
+++ b/test/resources/Availabilities.spec.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 
-import { getSpyableStelace } from '../../testUtils'
+import { getSpyableStelace, maxNbResultsPerPage } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
@@ -27,7 +27,8 @@ test('list: sends the correct request', (t) => {
         path: '/availabilities',
         data: {},
         queryParams: {
-          assetId: 'asset_1'
+          assetId: 'asset_1',
+          nbResultsPerPage: maxNbResultsPerPage // automatically added
         },
         headers: {}
       })

--- a/test/resources/Categories.spec.js
+++ b/test/resources/Categories.spec.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 
-import { getSpyableStelace } from '../../testUtils'
+import { getSpyableStelace, maxNbResultsPerPage } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
@@ -11,8 +11,25 @@ test('list: sends the correct request', (t) => {
         method: 'GET',
         path: '/categories',
         data: {},
-        queryParams: {},
+        queryParams: {
+          nbResultsPerPage: maxNbResultsPerPage // automatically added
+        },
         headers: {}
+      })
+    })
+})
+
+test('[2019-05-20] list: sends the correct request', (t) => {
+  return stelace.categories.list({ stelaceVersion: '2019-05-20' })
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'GET',
+        path: '/categories',
+        data: {},
+        queryParams: {},
+        headers: {
+          'x-stelace-version': '2019-05-20'
+        }
       })
     })
 })

--- a/test/resources/Roles.spec.js
+++ b/test/resources/Roles.spec.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 
-import { getSpyableStelace } from '../../testUtils'
+import { getSpyableStelace, maxNbResultsPerPage } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
@@ -11,8 +11,25 @@ test('list: sends the correct request', (t) => {
         method: 'GET',
         path: '/roles',
         data: {},
-        queryParams: {},
+        queryParams: {
+          nbResultsPerPage: maxNbResultsPerPage // automatically added
+        },
         headers: {}
+      })
+    })
+})
+
+test('[2019-05-20] list: sends the correct request', (t) => {
+  return stelace.roles.list({ stelaceVersion: '2019-05-20' })
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'GET',
+        path: '/roles',
+        data: {},
+        queryParams: {},
+        headers: {
+          'x-stelace-version': '2019-05-20'
+        }
       })
     })
 })

--- a/test/resources/SavedSearch.spec.js
+++ b/test/resources/SavedSearch.spec.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 
-import { getSpyableStelace } from '../../testUtils'
+import { getSpyableStelace, maxNbResultsPerPage } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
@@ -11,7 +11,9 @@ test('list: sends the correct request', (t) => {
         method: 'GET',
         path: '/search',
         data: {},
-        queryParams: {},
+        queryParams: {
+          nbResultsPerPage: maxNbResultsPerPage // automatically added
+        },
         headers: {}
       })
     })

--- a/test/resources/Webhooks.spec.js
+++ b/test/resources/Webhooks.spec.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 
-import { getSpyableStelace } from '../../testUtils'
+import { getSpyableStelace, maxNbResultsPerPage } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
@@ -11,8 +11,25 @@ test('list: sends the correct request', (t) => {
         method: 'GET',
         path: '/webhooks',
         data: {},
-        queryParams: {},
+        queryParams: {
+          nbResultsPerPage: maxNbResultsPerPage // automatically added
+        },
         headers: {}
+      })
+    })
+})
+
+test('list: sends the correct request', (t) => {
+  return stelace.webhooks.list({ stelaceVersion: '2019-05-20' })
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'GET',
+        path: '/webhooks',
+        data: {},
+        queryParams: {},
+        headers: {
+          'x-stelace-version': '2019-05-20'
+        }
       })
     })
 })

--- a/test/resources/Workflows.spec.js
+++ b/test/resources/Workflows.spec.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 
-import { getSpyableStelace } from '../../testUtils'
+import { getSpyableStelace, maxNbResultsPerPage } from '../../testUtils'
 
 const stelace = getSpyableStelace()
 
@@ -11,8 +11,25 @@ test('list: sends the correct request', (t) => {
         method: 'GET',
         path: '/workflows',
         data: {},
-        queryParams: {},
+        queryParams: {
+          nbResultsPerPage: maxNbResultsPerPage // automatically added
+        },
         headers: {}
+      })
+    })
+})
+
+test('[2019-05-20] list: sends the correct request', (t) => {
+  return stelace.workflows.list({ stelaceVersion: '2019-05-20' })
+    .then(() => {
+      t.deepEqual(stelace.LAST_REQUEST, {
+        method: 'GET',
+        path: '/workflows',
+        data: {},
+        queryParams: {},
+        headers: {
+          'x-stelace-version': '2019-05-20'
+        }
       })
     })
 })

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -3,6 +3,8 @@ import jwt from 'jsonwebtoken'
 
 import { createInstance } from '../lib/stelace'
 
+export { maxNbResultsPerPage } from '../lib/utils'
+
 export function getApiKey ({ type = 'seck' } = {}) {
   const secretKey = 'seck_test_wakWA41rBTUXs1Y5oNRjeY5o'
   const publishableKey = 'pubk_test_wakWA41rBTUXs1Y5oNRjeY5o'


### PR DESCRIPTION
Via two ways:
- async iterator
- `autoPagingToArray` function

Additional change: explicitly pass the maximum number
of results per page for list endpoints that supports pagination,
when the parameter `nbResultsPerPage` is absent.